### PR TITLE
bug fix: MC update should be performed after reward accumulation

### DIFF
--- a/2024-25/agents/tabular.py
+++ b/2024-25/agents/tabular.py
@@ -207,7 +207,10 @@ class MonteCarlo(TabularAgent):
                 G = sum([reward * (self.gamma ** i) for i, (_, _, reward) in enumerate(episode[first_occurrence:])])
                 self.G_values[(state, action)] += G 
                 self.G_count[(state, action)] += 1
+            
+            for state, action in visited_pairs:
                 error = self.update(state, action, None, None, None)
+            
             if i % save_every == 0:
                 self.history.append(self.Q.copy())
                 self.error.append(error)


### PR DESCRIPTION
This PR fixes an issue in the Monte Carlo Q-function update logic. Previously, Q-values were updated during return accumulation, which caused them to be computed based on incomplete statistics. Although the implementation used first-visit returns, this ordering introduced a bias and led to unstable or inaccurate estimates.

see the attached plots for a comparison:
### Before:
<img width="1188" height="390" alt="image" src="https://github.com/user-attachments/assets/fb661668-d56e-442b-be4c-e3fe2ee73520" />

### After
<img width="1187" height="390" alt="image" src="https://github.com/user-attachments/assets/ad0b3818-864b-4a7d-aa99-859281767c77" />

